### PR TITLE
chore(git): extend amend alias to support arbitrary refs

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -64,7 +64,7 @@
     filelog = log -u
     fl = log -u
     # Ammend previous commit
-    amend = commit --amend --reset-author -v
+    amend = "!f() { if [ -n \"$1\" ]; then GIT_SEQUENCE_EDITOR=\"sed -i '' '1s/^pick/edit/'\" git rebase -i \"$1^\"; else git commit --amend --reset-author -v; fi; }; f"
     # Rebase and update everything
     up = !git pull --rebase --prune $@ && git submodule update --init --recursive
     sync = !git rebase $1 && git push -u origin HEAD --force


### PR DESCRIPTION
## Why
The existing `git amend` alias only worked on HEAD. This extends it to support amending any commit (e.g. `git amend HEAD~2`) by using an interactive rebase under the hood, keeping the familiar `amend` verb for both cases.

## What changed
- Converted `amend` alias from a plain `commit --amend` to a `!f()` shell function
- No-arg path is unchanged: `git commit --amend --reset-author -v`
- With a ref arg: sets `GIT_SEQUENCE_EDITOR` to auto-mark the target commit as `edit`, then starts `git rebase -i <ref>^`

## Test Plan
- [ ] `git amend` (no args) opens editor for HEAD as before
- [ ] `git amend HEAD~2` pauses rebase at target commit for editing
- [ ] After staging changes: `git amend` + `git rebase --continue` completes cleanly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)