### PR TITLE
fix(mac): make clean-machine setup work without manual steps

### DIFF
--- a/scripts/mac/install.sh
+++ b/scripts/mac/install.sh
@@ -12,6 +12,28 @@ if ! xcode-select -p &>/dev/null; then
   exit 1
 fi
 
+if [[ ! -e '/etc/pam.d/sudo_local' ]]; then
+  echo "> Enable Touch ID for sudo"
+  sed "s/^#auth/auth/" /etc/pam.d/sudo_local.template | sudo tee /etc/pam.d/sudo_local
+fi
+
+# Link safe configs early, before the riskier Homebrew/oh-my-zsh/nvim steps, so a
+# failure there still leaves a working shell + git + gnupg config.
+echo "> Symlinking dotfiles"
+ln -sfn "${DOTFILES_DIR}/.tmux.conf"           "${HOME}/.tmux.conf"
+ln -sfn "${DOTFILES_DIR}/.gitconfig"           "${HOME}/.gitconfig"
+ln -sfn "${DOTFILES_DIR}/.git-commit-tmpl.txt" "${HOME}/.git-commit-tmpl.txt"
+ln -sfn "${DOTFILES_DIR}/.gitconfig.local.mac" "${HOME}/.gitconfig.local"
+# .bashrc intentionally omitted: not in repo; .bash_profile guards its source.
+for f in .bash_profile .bash_aliases .bash_functions .bash_paths \
+         .bash_exports .bash_prompt .inputrc .dockerfunc; do
+  ln -sfn "${DOTFILES_DIR}/${f}" "${HOME}/${f}"
+done
+mkdir -p "${HOME}/.gnupg"
+chmod 700 "${HOME}/.gnupg"
+ln -sfn "${DOTFILES_DIR}/.gnupg/gpg.conf"           "${HOME}/.gnupg/gpg.conf"
+ln -sfn "${DOTFILES_DIR}/.gnupg/gpg-agent.conf.mac" "${HOME}/.gnupg/gpg-agent.conf"
+
 if [[ ! -d '/opt/homebrew/bin' ]]; then
   echo "> Install Homebrew"
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -21,18 +43,22 @@ if [[ ! -d '/opt/homebrew/bin' ]]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-if [[ ! -e '/etc/pam.d/sudo_local' ]]; then
-  echo "> Enable Touch ID for sudo"
-  sed "s/^#auth/auth/" /etc/pam.d/sudo_local.template | sudo tee /etc/pam.d/sudo_local
-fi
-
 echo "> Install usual applications"
-PKGS=(neovim tmux bat fzf jq ripgrep shellcheck pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy)
+PKGS=(neovim tmux bat fzf jq ripgrep shellcheck gnupg pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy)
 MISSING=()
 for pkg in "${PKGS[@]}"; do
   brew list --formula "$pkg" &>/dev/null || brew list --cask "$pkg" &>/dev/null || MISSING+=("$pkg")
 done
 [[ ${#MISSING[@]} -gt 0 ]] && brew install "${MISSING[@]}"
+
+# Needs gpg on PATH, so it must run after the brew install above.
+if command -v gpg >/dev/null 2>&1; then
+  gpg_dir=$(dirname "$(which gpg)")
+  if [[ ! -e "${gpg_dir}/gpg2" ]]; then
+    echo "> Add gpg2 symlink (probably on macOS)"
+    ln -sfn "${gpg_dir}/gpg" "${gpg_dir}/gpg2"
+  fi
+fi
 
 if [[ ! -d "/Users/${USER}/.oh-my-zsh" ]]; then
   echo "> Install Oh My ZSH"
@@ -44,23 +70,7 @@ if [[ ! -d "$HOME/.config/nvim" ]]; then
   git clone git@github.com:r2dkennobi/nvim.git "$HOME/.config/nvim"
 fi
 
-if command -v gpg >/dev/null 2>&1; then
-  gpg_dir=$(dirname "$(which gpg)")
-  if [[ ! -e "${gpg_dir}/gpg2" ]]; then
-    echo "> Add gpg2 symlink (probably on macOS)"
-    ln -sfn "${gpg_dir}/gpg" "${gpg_dir}/gpg2"
-  fi
-fi
-
-echo "> Symlinking dotfiles"
-ln -sfn "${DOTFILES_DIR}/.tmux.conf"           "${HOME}/.tmux.conf"
-ln -sfn "${DOTFILES_DIR}/.gitconfig"           "${HOME}/.gitconfig"
-ln -sfn "${DOTFILES_DIR}/.git-commit-tmpl.txt" "${HOME}/.git-commit-tmpl.txt"
-mkdir -p "${HOME}/.gnupg"
-ln -sfn "${DOTFILES_DIR}/.gnupg/gpg.conf"             "${HOME}/.gnupg/gpg.conf"
-ln -sfn "${DOTFILES_DIR}/.gnupg/gpg-agent.conf.mac"   "${HOME}/.gnupg/gpg-agent.conf"
-ln -sfn "${DOTFILES_DIR}/.gitconfig.local.mac"         "${HOME}/.gitconfig.local"
-
+# Must run after oh-my-zsh, whose installer overwrites ~/.zshrc.
 LINE="source ${DOTFILES_DIR}/.zsh_custom"
 FILE="${HOME}/.zshrc"
 if ! grep -qF "$LINE" "$FILE"; then


### PR DESCRIPTION
## Why
A clean setup on a new Mac required several manual interventions before the environment was usable: Homebrew failed amid repeated `sudo` password prompts, the bash dotfiles had to be linked by hand afterward, `gnupg` wasn't installed at all (so commit signing and the `gpg2`-based git/alias config were broken), and `gpg` warned about unsafe `~/.gnupg` permissions on first use. This makes `bootstrap.sh` produce a fully working shell + GPG setup with no manual follow-up.

## What changed
- Move the Touch ID-for-sudo setup ahead of the Homebrew install so Homebrew's own `sudo` calls authenticate via Touch ID instead of repeated password prompts.
- Move the dotfile + gnupg-config symlinking (now including the bash/input dotfiles) to run early, before the riskier Homebrew/oh-my-zsh/nvim steps, so a failure there still leaves a working shell + git + gnupg config.
- Add `.bash_profile`, `.bash_aliases`, `.bash_functions`, `.bash_paths`, `.bash_exports`, `.bash_prompt`, `.inputrc`, `.dockerfunc` symlinks (`.bashrc` omitted — not in repo and already guarded).
- Add `gnupg` (and keep `pinentry-mac`) to the brew package list so `gpg` exists; the existing `gpg2` symlink block now runs after install and creates `gpg2 -> gpg` (needed by `.gitconfig program = gpg2` and the `gpgla`/`gpgsla` aliases).
- `chmod 700 ~/.gnupg` to silence the unsafe-permissions warning.

## Test Plan
- [ ] `shellcheck scripts/mac/install.sh` clean (one pre-existing intentional SC2016 info)
- [ ] Full run on a fresh Mac / clean account via `./bootstrap.sh`: Homebrew installs without repeated password prompts, no manual linking needed afterward
- [ ] `which gpg gpg2 pinentry-mac` all resolve; `gpg --list-keys` runs with no "unsafe permissions on homedir" warning; `stat -f '%Lp' ~/.gnupg` prints `700`
- [ ] New symlinks resolve into the dotfiles repo (`ls -l ~/.bash_profile ~/.bash_aliases ~/.inputrc`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)