### PR TITLE
feat(mac): install latest python and symlink ssh config

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -1,0 +1,3 @@
+Host *
+    IdentitiesOnly yes
+    AddKeysToAgent yes

--- a/scripts/mac/install.sh
+++ b/scripts/mac/install.sh
@@ -33,6 +33,9 @@ mkdir -p "${HOME}/.gnupg"
 chmod 700 "${HOME}/.gnupg"
 ln -sfn "${DOTFILES_DIR}/.gnupg/gpg.conf"           "${HOME}/.gnupg/gpg.conf"
 ln -sfn "${DOTFILES_DIR}/.gnupg/gpg-agent.conf.mac" "${HOME}/.gnupg/gpg-agent.conf"
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+ln -sfn "${DOTFILES_DIR}/.ssh/config" "${HOME}/.ssh/config"
 
 if [[ ! -d '/opt/homebrew/bin' ]]; then
   echo "> Install Homebrew"
@@ -44,7 +47,7 @@ if [[ ! -d '/opt/homebrew/bin' ]]; then
 fi
 
 echo "> Install usual applications"
-PKGS=(neovim tmux bat fzf jq ripgrep shellcheck gnupg pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy)
+PKGS=(neovim tmux bat fzf jq ripgrep shellcheck gnupg pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy python)
 MISSING=()
 for pkg in "${PKGS[@]}"; do
   brew list --formula "$pkg" &>/dev/null || brew list --cask "$pkg" &>/dev/null || MISSING+=("$pkg")


### PR DESCRIPTION
## Why
On macOS the installer never set up Python or an SSH config, so a machine relied on incidental/system Python and had no managed `~/.ssh/config`. This makes a fresh install reliably pick up the latest stable Python and lay down sensible SSH defaults.

## What changed
- Added `python` to the Homebrew package list in `scripts/mac/install.sh` so installs track Homebrew's latest stable Python (`python3`/`pip3` land on PATH via `brew shellenv`).
- Added a tracked `.ssh/config` (`Host *`: `IdentitiesOnly yes`, `AddKeysToAgent yes`) and a symlink step in the installer that creates `~/.ssh` (mode 700) and links the config, mirroring the existing GnuPG block.

## Test Plan
- [ ] Run `bash scripts/mac/install.sh` on macOS
- [ ] `which python3` → `/opt/homebrew/bin/python3`; `python3 --version` matches `brew info python`
- [ ] Re-run installer — `python` is not reinstalled (idempotent)
- [ ] `readlink ~/.ssh/config` points into the repo; `ls -ld ~/.ssh` shows `700`
- [ ] `ssh -G github.com` reflects `identitiesonly yes` / `addkeystoagent yes` with no config-permission warning

## Notes
- Homebrew links `python3`, not bare `python` (standard behavior).
- `brew upgrade` is still needed periodically to stay on the latest; the installer only installs missing packages.
- The installer's `ln -sfn` overwrites an existing `~/.ssh/config` — back up first if you have a real one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)