### PR TITLE
fix(mac): always write brew shellenv to ~/.zprofile, not just on fresh install

### DIFF
--- a/scripts/mac/install.sh
+++ b/scripts/mac/install.sh
@@ -44,14 +44,20 @@ fi
 # /bin/bash). brew shellenv PREPENDS to PATH, overriding the order that path_helper
 # applies from /etc/paths + /etc/paths.d/homebrew.
 #
-# Run this unconditionally and idempotently: when Homebrew is pre-installed (e.g. by
-# MDM) the block above is skipped, but ~/.zprofile still needs this line.
-BREW_SHELLENV='eval "$(/opt/homebrew/bin/brew shellenv)"'
-if ! grep -qF "$BREW_SHELLENV" "/Users/${USER}/.zprofile" 2>/dev/null; then
-  echo "> Add Homebrew shellenv to ~/.zprofile"
-  printf '\n%s\n' "$BREW_SHELLENV" >> "/Users/${USER}/.zprofile"
+# Run this idempotently: when Homebrew is pre-installed (e.g. by MDM) the block
+# above is skipped, but ~/.zprofile still needs this line. Gate on brew actually
+# existing at the expected path so we don't write a line that errors in every
+# future shell (e.g. on Intel, where Homebrew lives in /usr/local, not here).
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  BREW_SHELLENV='eval "$(/opt/homebrew/bin/brew shellenv)"'
+  if ! grep -qF "$BREW_SHELLENV" "/Users/${USER}/.zprofile" 2>/dev/null; then
+    echo "> Add Homebrew shellenv to ~/.zprofile"
+    printf '\n%s\n' "$BREW_SHELLENV" >> "/Users/${USER}/.zprofile"
+  fi
+  eval "$BREW_SHELLENV"
+else
+  echo "> WARNING: /opt/homebrew/bin/brew not found — skipping shellenv setup" >&2
 fi
-eval "$(/opt/homebrew/bin/brew shellenv)"
 
 echo "> Install usual applications"
 PKGS=(neovim tmux bat fzf jq ripgrep shellcheck gnupg pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy)

--- a/scripts/mac/install.sh
+++ b/scripts/mac/install.sh
@@ -37,11 +37,21 @@ ln -sfn "${DOTFILES_DIR}/.gnupg/gpg-agent.conf.mac" "${HOME}/.gnupg/gpg-agent.co
 if [[ ! -d '/opt/homebrew/bin' ]]; then
   echo "> Install Homebrew"
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-  echo >> "/Users/${USER}/.zprofile"
-  echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "/Users/${USER}/.zprofile"
-  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
+
+# Ensure Homebrew is on PATH ahead of macOS system paths, so `bash`, `gpg`, etc.
+# resolve to the Homebrew versions and not the stock ones (macOS ships bash 3.2 at
+# /bin/bash). brew shellenv PREPENDS to PATH, overriding the order that path_helper
+# applies from /etc/paths + /etc/paths.d/homebrew.
+#
+# Run this unconditionally and idempotently: when Homebrew is pre-installed (e.g. by
+# MDM) the block above is skipped, but ~/.zprofile still needs this line.
+BREW_SHELLENV='eval "$(/opt/homebrew/bin/brew shellenv)"'
+if ! grep -qF "$BREW_SHELLENV" "/Users/${USER}/.zprofile" 2>/dev/null; then
+  echo "> Add Homebrew shellenv to ~/.zprofile"
+  printf '\n%s\n' "$BREW_SHELLENV" >> "/Users/${USER}/.zprofile"
+fi
+eval "$(/opt/homebrew/bin/brew shellenv)"
 
 echo "> Install usual applications"
 PKGS=(neovim tmux bat fzf jq ripgrep shellcheck gnupg pinentry-mac font-cascadia-code-pl font-cascadia-mono-pl tree diff-so-fancy)


### PR DESCRIPTION
## Problem

The macOS installer only appends `eval "$(/opt/homebrew/bin/brew shellenv)"` to `~/.zprofile`
**inside** the `[[ ! -d /opt/homebrew/bin ]]` block — i.e. only when it installs Homebrew itself.

On a machine where Homebrew is **already present** (e.g. pre-provisioned by MDM), that block is
skipped, so `~/.zprofile` never gets the line. Without it, `/opt/homebrew/bin` is only added via
`/etc/paths.d/homebrew`, which `path_helper` **appends after** `/usr/bin:/bin`. Net effect: `bash`
resolves to macOS's stock **3.2** at `/bin/bash` instead of the Homebrew **5.x**, which breaks any
script using bash 4+ features (`mapfile`, `${var,,}`, etc.).

## Fix

- Move the `brew shellenv` → `~/.zprofile` setup **out** of the install-only block so it runs on
  every macOS bootstrap.
- Make it **idempotent** with a `grep -qF` guard so re-runs don't duplicate the line.
- Keep the `eval "$(... shellenv)"` in the current shell so the rest of the installer (brew install)
  works whether or not this run installed Homebrew.

## Testing

- `bash -n scripts/mac/install.sh` passes; shellcheck clean.
- Verified on an affected machine: after adding the line to `~/.zprofile`, a fresh login shell
  resolves `bash → /opt/homebrew/bin/bash` (GNU bash 5.3.15) and `/opt/homebrew/bin` is first in PATH.
- The idempotency guard matches an existing `~/.zprofile` line, so a re-run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)